### PR TITLE
Implement flashdeltaall and nodeid prefixing

### DIFF
--- a/stormloader/main.py
+++ b/stormloader/main.py
@@ -345,8 +345,9 @@ def act_programall_kernel_payload(args):
         print
 
 def act_program_kernel_payload(args, ftdi_device_id=None):
+    cache_file = '.cached_payload' if ftdi_device_id is None else '.cached_payload_{0}'.format(ftdi_device_id)
     try:
-        eximage = open(".cached_payload","r").read()
+        eximage = open(cache_file,"r").read()
     except:
         eximage = None
     try:
@@ -468,7 +469,7 @@ def act_program_kernel_payload(args, ftdi_device_id=None):
         else:
             print "No cached contents (this will take longer)"
             wfull()
-        with open(".cached_payload","w") as f:
+        with open(cache_file,"w") as f:
             f.write(img)
 
         sl.enter_payload_mode()

--- a/stormloader/main.py
+++ b/stormloader/main.py
@@ -848,12 +848,12 @@ local-gateway-addr=10.4.10.1
     # setup to write values
     sl = sl_api.StormLoader(args["tty"])
     sl.enter_bootload_mode()
-    if args["config"]:
+    if args["configfile"]:
         if args["verbose"]:
-            print "Loading config from", args["config"]
+            print "Loading config from", args["configfile"]
         from ConfigParser import SafeConfigParser
         cparser = SafeConfigParser()
-        cparser.read(args["config"])
+        cparser.read(args["configfile"])
         args["mesh_ip6_prefix"] = cparser.get('main', 'mesh-ip6-prefix')
         args["remote_tunnel_addr"] = cparser.get('main', 'remote-tunnel-addr')
         args["local_tunnel_addr"] = cparser.get('main', 'local-tunnel-addr')

--- a/stormloader/main.py
+++ b/stormloader/main.py
@@ -201,9 +201,19 @@ def act_flash(args, ftdi_device_id=None):
         print "Fatal error:", e
         sys.exit(1)
 
-def act_delta(args):
+def act_deltaall(args):
+    devices = sl_api.StormLoader.list_devices()
+    print "Found: ", " ".join(devices)
+    _args = loadconfigs(args, "flashdelta")
+    map_ftdi_to_nodeid(devices, _args.get("tty", None))
+    for dev in devices:
+        print ">>> Programming: "+dev
+        act_delta(args, ftdi_device_id=dev)
+        print
+
+def act_delta(args, ftdi_device_id=None):
     args = loadconfigs(args, "flashdelta")
-    sl = sl_api.StormLoader(args.get("tty", None))
+    sl = sl_api.StormLoader(args.get("tty", None), device_id=ftdi_device_id)
     sl.enter_bootload_mode()
 
     newcell = SLCell.load(args["newimg"])
@@ -937,6 +947,11 @@ def entry():
     p_delta.set_defaults(func=act_delta)
     p_delta.add_argument("oldimg", help="the sdb file that was last used to program the device")
     p_delta.add_argument("newimg", help="the new sdb file to program")
+
+    p_deltaall = sp.add_parser("flashalldelta")
+    p_deltaall.set_defaults(func=act_deltaall)
+    p_deltaall.add_argument("oldimg", help="the sdb file that was last used to program the device")
+    p_deltaall.add_argument("newimg", help="the new sdb file to program")
 
     p_payload = sp.add_parser("program", help="program an ELF to the payload section")
     p_payload.set_defaults(func=act_program_kernel_payload)


### PR DESCRIPTION
Forgot to include flashdelta all in the last PR. Also adds nodeid prefixing for `sload tailall -p`, which goes from this:

```
[DN00DW22]  
[DN00DW22]  SERIAL NUMBER 0x304d
[DN00DW22]  IPAddress - Setting global address: 2001:470:83ae:2:212:6d02::304d
[DN00DW22]  error? 1 length 5
[DN00DW22]  Loading prefix from flash attribute 2: :212:6d02:0:304d
[DN00DW22]  IPAddress - Setting global address: :212:6d02:0:304d
[DN00DW22]  Booting kernel 4.0.7.0 (848c5d3281462fc9b1b407cdf9ac0cd02465fc1f)
[DN00DW22]  Starting init RPL
[DN00DW22]  not root, starting periodic
[DN00DW1I]  SERIAL NUMBER 0x310b
[DN00DW22]  Boo
[DN00DW1I]  IPAddress - Setting global address: 2001:470:83ae:2:212:6d02::310b
[DJ00DH9S]  SERIAL NUMBER 0x4013
[DN00DW1I]  error? 1 length 5
[DN00DW1I]  Loading prefix from flash attribute 2: :212:6d02:0:310b
```

to this

```
[304d]  
[304d]  SERIAL NUMBER 0x304d
[304d]  IPAddress - Setting global address: 2001:470:83ae:2:212:6d02::304d
[304d]  error? 1 length 5
[304d]  Loading prefix from flash attribute 2: :212:6d02:0:304d
[304d]  IPAddress - Setting global address: :212:6d02:0:304d
[304d]  Booting kernel 4.0.7.0 (848c5d3281462fc9b1b407cdf9ac0cd02465fc1f)
[304d]  Starting init RPL
[304d]  not root, starting periodic
[310b]  SERIAL NUMBER 0x310b
[304d]  Boo
[310b]  IPAddress - Setting global address: 2001:470:83ae:2:212:6d02::310b
[4013]  SERIAL NUMBER 0x4013
[310b]  error? 1 length 5
[4013]  IPAddress - Setting global address: 2001:470:83ae:2:212:6d02::4013
[310b]  Loading prefix from flash attribute 2: :212:6d02:0:310b
[310b]  IPAddress - Setting global address: :212:6d02:0:310b
[4013]  error? 1 length 5
[4013]  Booting kernel 4.0.7.0 (848c5d3281462fc9b1b407cdf9ac0cd02465fc1f)
[304d]  ting payload 4.0:asking for time
[310b]  Booting kernel 4.0.7.0 (848c5d3281462fc9b1b407cdf9ac0cd02465fc1f)
[310b]  Starting init RPL
[4013]  Starting init RPL
[4013]  not root, starting periodic
```
